### PR TITLE
README now reminds users to add font in Rakefile

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,23 @@ Following on that lead, MotionAwesome brings similar awesomeness in the RubyMoti
 gem install motion-awesome
 ```
 
+If you are using Bundler in your Rubymotion, you can add the gem to your Gemfile and run `bundle install`:
+
+```
+gem 'motion-awesome'
+```
+
+The FontAwesome font file will automatically be copied to your resources folder. Make sure to include the font in your Rakefile:
+
+```ruby
+# ...
+Motion::Project::App.setup do |app|
+  # ...
+
+  app.fonts = ['fontawesome-webfont.ttf']
+end
+```
+
 ## Dependencies
 
 - motion-map [https://github.com/derailed/motion-map]


### PR DESCRIPTION
The app was crashing when I was adding a MotionAwesome label to a view because my Rakefile didn't specify to load in the font file. This adds a reminder to do so in the README.
